### PR TITLE
Fix #5.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV VERSION=$VERSION
 ENV BUILD_DATE=$BUILD_DATE
 
 RUN mkdir /assistant_relay \
+&& touch /assistant_relay/bin/config.json \
 && npm i pm2 -g
 
 WORKDIR /assistant_relay

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV LANG C.UTF-8
 ENV VERSION=$VERSION
 ENV BUILD_DATE=$BUILD_DATE
 
-RUN mkdir /assistant_relay \
+RUN mkdir -p /assistant_relay/bin \
 && touch /assistant_relay/bin/config.json \
 && npm i pm2 -g
 


### PR DESCRIPTION
Touch an empty file for bind mounting the config file.

`-v /path/to/volume/config.json:/assistant_relay/bin/config.json:rw` creates a directory if `/assistant_relay/bin/config.json` doesn't exist in the container[1].
Then, GAR fails to start because it's trying to call FileSync()[2] on a directory.


[1] From https://docs.docker.com/storage/bind-mounts/
> If you use -v or --volume to bind-mount a file or directory that does not yet exist on the Docker host, -v creates the endpoint for you. It is always created as a directory.

[2] https://github.com/greghesp/assistant-relay/blob/ca3efec955c950ae76079f92f3e773a5ce412f1d/relay/helpers/server.js#L10